### PR TITLE
ES7 stores

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -17,7 +17,9 @@
     "<="
   ],
   "excludeFiles": [
-    "dist/*"
+    "dist/*",
+    "src/store/__tests__/handlesSpec.js",
+    "src/store/__tests__/storeClassProperties.js"
   ],
   "maximumLineLength": {
     "value": 120,

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,1 +1,3 @@
 dist/*
+src/store/__tests__/handlesSpec.js
+src/store/__tests__/storeClassProperties.js

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var _ = require('lodash');
 var yaml = require('js-yaml');
 var shell = require('shelljs');
+var babelify = require('babelify');
 
 var SCRIPTS = [
   './src/http-state-source/__tests__/lib/mockServer.js'
@@ -119,7 +120,14 @@ module.exports = function (config) {
       browserNoActivityTimeout: 100000,
       browserify: {
         bare: true,
-        debug: true
+        debug: true,
+        configure: function (bundle) {
+          bundle.transform(babelify.configure({
+            optional: ['es7.decorators', 'es7.classProperties']
+          }));
+
+          bundle.transform('envify');
+        }
       },
       files: [
         'test/browser/setup.js',

--- a/src/store/__tests__/handlesSpec.js
+++ b/src/store/__tests__/handlesSpec.js
@@ -1,0 +1,32 @@
+let _ = require('lodash');
+let sinon = require('sinon');
+let expect = require('chai').expect;
+let { dispatch } = require('../../test-utils');
+let buildMarty = require('../../../test/lib/buildMarty');
+
+describe('@handles', () => {
+  let app, Marty, handler;
+
+  beforeEach(() => {
+    Marty = buildMarty();
+    handler = sinon.stub();
+
+    class UserStore extends Marty.Store {
+      @Marty.handles('FOO', 'BAR')
+      actionHandler(foo, bar) {
+        handler(foo, bar);
+      }
+    }
+
+    app = new Marty.Application();
+    app.register('store', UserStore);
+
+    dispatch(app, 'FOO', 1, 2);
+    dispatch(app, 'BAR', 'a', 'b');
+  });
+
+  it('should handle the dispatched actions', () => {
+    expect(handler).to.be.calledWith(1, 2);
+    expect(handler).to.be.calledWith('a', 'b');
+  });
+});

--- a/src/store/__tests__/storeClassProperties.js
+++ b/src/store/__tests__/storeClassProperties.js
@@ -1,0 +1,64 @@
+let _ = require('lodash');
+let sinon = require('sinon');
+let expect = require('chai').expect;
+let { dispatch } = require('../../test-utils');
+let buildMarty = require('../../../test/lib/buildMarty');
+
+describe('Store statics', () => {
+  let app, Marty, handler;
+
+  beforeEach(() => {
+    Marty = buildMarty();
+    handler = sinon.stub();
+  });
+
+  describe('when class properties', () => {
+    beforeEach(() => {
+      class UserStore extends Marty.Store {
+        handlers = {
+          actionHandler: ['FOO', 'BAR']
+        }
+
+        actionHandler(foo, bar) {
+          handler(foo, bar);
+        }
+      }
+
+      app = new Marty.Application();
+      app.register('store', UserStore);
+
+      dispatch(app, 'FOO', 1, 2);
+      dispatch(app, 'BAR', 'a', 'b');
+    });
+
+    it('should handle the dispatched actions', () => {
+      expect(handler).to.be.calledWith(1, 2);
+      expect(handler).to.be.calledWith('a', 'b');
+    });
+  });
+
+  describe('when static properties', () => {
+    beforeEach(() => {
+      class UserStore extends Marty.Store {
+        actionHandler(foo, bar) {
+          handler(foo, bar);
+        }
+      }
+
+      UserStore.handlers = {
+        actionHandler: ['FOO', 'BAR']
+      };
+
+      app = new Marty.Application();
+      app.register('store', UserStore);
+
+      dispatch(app, 'FOO', 1, 2);
+      dispatch(app, 'BAR', 'a', 'b');
+    });
+
+    it('should handle the dispatched actions', () => {
+      expect(handler).to.be.calledWith(1, 2);
+      expect(handler).to.be.calledWith('a', 'b');
+    });
+  });
+});

--- a/src/store/getHandlers.js
+++ b/src/store/getHandlers.js
@@ -1,0 +1,7 @@
+let { extend } = require('../mindash');
+
+function getHandlers(store) {
+  return extend({}, store.handlers, store.constructor.handlers);
+}
+
+module.exports = getHandlers;

--- a/src/store/handleAction.js
+++ b/src/store/handleAction.js
@@ -1,10 +1,11 @@
 let _ = require('../mindash');
+let getHandlers = require('./getHandlers');
 
 function handleAction(action) {
   this.__validateHandlers();
 
   let store = this;
-  let handlers = _.object(_.map(store.handlers, getHandlerWithPredicates));
+  let handlers = _.object(_.map(getHandlers(store), getHandlerWithPredicates));
 
   _.each(handlers, function (predicates, handlerName) {
     _.each(predicates, function (predicate) {

--- a/src/store/handles.js
+++ b/src/store/handles.js
@@ -1,0 +1,15 @@
+let { toArray, extend } = require('../mindash');
+
+function handles() {
+  let constants = toArray(arguments);
+
+  return function (target, name, descriptor) {
+    target.handlers = extend({}, target.handlers, {
+      [name]: constants
+    });
+
+    return descriptor;
+  };
+}
+
+module.exports = handles;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,5 +2,6 @@ module.exports = function (marty) {
   marty.when = require('./when');
   marty.fetch = require('./fetch');
   marty.Store = require('./store');
+  marty.handles = require('./handles');
   marty.createStore = require('./createStoreClass');
 };

--- a/src/store/validateHandlers.js
+++ b/src/store/validateHandlers.js
@@ -1,9 +1,10 @@
 let _ = require('../mindash');
+let getHandlers = require('./getHandlers');
 let ActionHandlerNotFoundError = require('../errors/actionHandlerNotFoundError');
 let ActionPredicateUndefinedError = require('../errors/actionPredicateUndefinedError');
 
 function validateHandlers(store) {
-  _.each(store.handlers, (actionPredicate, handlerName) => {
+  _.each(getHandlers(store), (actionPredicate, handlerName) => {
     let actionHandler = store[handlerName];
 
     if (_.isUndefined(actionHandler) || _.isNull(actionHandler)) {

--- a/src/test-utils/createApplication.js
+++ b/src/test-utils/createApplication.js
@@ -1,0 +1,47 @@
+var _ = require('../mindash');
+var DEFAULT_OPTIONS = {
+  include: [],
+  exclude: [],
+  stub: {}
+};
+
+function createApplication(Application, options) {
+  var {
+    include,
+    exclude,
+    stub
+  } = _.defaults(options || {}, DEFAULT_OPTIONS);
+
+  // Inherit from application so we modify prototype
+  class TestApplication extends Application { }
+
+  var _register = TestApplication.prototype.register;
+
+  if (!_.isArray(include)) {
+    include = [include];
+  }
+
+  if (!_.isArray(exclude)) {
+    exclude = [exclude];
+  }
+
+  TestApplication.prototype.register = function stubRegister(key, value) {
+    if (!_.isString(key)) {
+      _register.apply(this, arguments);
+    } else if (stub[key]) {
+      this[key] = stub[key];
+    } else if (include.length) {
+      if (include.indexOf(key) !== -1) {
+        _register.call(this, key, value);
+      }
+    } else if (exclude.length) {
+      if (include.indexOf(key) === -1) {
+        _register.call(this, key, value);
+      }
+    }
+  }
+
+  return new TestApplication();
+}
+
+module.exports = createApplication;

--- a/src/test-utils/createApplication.js
+++ b/src/test-utils/createApplication.js
@@ -39,7 +39,7 @@ function createApplication(Application, options) {
         _register.call(this, key, value);
       }
     }
-  }
+  };
 
   return new TestApplication();
 }

--- a/src/test-utils/dispatch.js
+++ b/src/test-utils/dispatch.js
@@ -1,0 +1,16 @@
+function dispatch(app, type, ...args) {
+  if (!app) {
+    throw new Error('Must specify the application');
+  }
+
+  if (!type) {
+    throw new Error('Must specify the action type');
+  }
+
+  return app.dispatcher.dispatchAction({
+    type: type,
+    arguments: args
+  });
+}
+
+module.exports = dispatch;

--- a/src/test-utils/index.js
+++ b/src/test-utils/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  dispatch: require('./dispatch'),
+  createApplication: require('./createApplication')
+};


### PR DESCRIPTION
**@handles**

Support for `@handles` decorator instead of `Store#handlers` (Requires 'es7.decorators' enabled with babel)

``` js
let { handles } = require('marty');

class UserStore extends Marty.Store {
  @handles("RECIEVE_USER", "CREATE_USER")
  recieveUser(user) {
    ...
  }
}
```

**Static handlers**

You can define handlers on the static or as a class property (Requires 'es7.classProperties' enabled with babel)

``` js
class UserStore extends Marty.Store {
  static handlers = {
    receiveUser: ["RECEIVE_USER", "CREATE_USER"]
  }

  receiveUser(user) {
    ...
  }
}

UserStore.handlers = {
  receiveUser: ["RECEIVE_USER", "CREATE_USER"]
};
```

Resolves martyjs/marty#262
