### PR TITLE
Fix Unexpected end of input in react native apps.

### DIFF
--- a/src/core/appProperty.js
+++ b/src/core/appProperty.js
@@ -7,7 +7,7 @@ function appProperty(obj) {
         return findApp(this);
       },
       set: function () {
-        // Do nothing until https://github.com/gaearon/react-hot-api/pull/16 is resolves
+        /* Do nothing until https://github.com/gaearon/react-hot-api/pull/16 is resolves */
       }
     });
   }


### PR DESCRIPTION
When you run the build this comment ends up below module.exports. This causes any react native app that includes marty-native to crash instantly with an error of `Unexpected end of input`.
