### PR TITLE
verbose decorator handles

### DIFF
--- a/src/store/handles.js
+++ b/src/store/handles.js
@@ -1,9 +1,15 @@
-let { toArray, extend } = require('../mindash');
+let { toArray, extend, each } = require('../mindash');
 
 function handles() {
   let constants = toArray(arguments);
+  each(constants, function(constant) {
+      if(!constant) {
+        console.error(new Error('Handles is used with an empty constant'));
+      }
+  })
 
   return function (target, name, descriptor) {
+
     target.handlers = extend({}, target.handlers, {
       [name]: constants
     });


### PR DESCRIPTION
I added some check that logs errors if '@handles' is used with an undefined constant.
